### PR TITLE
Upgrade project to .NET 8.0 LTS and update related configurations

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "C# (.NET)",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/dotnet:1-9.0-bookworm",
+	"image": "mcr.microsoft.com/devcontainers/dotnet:dev-8.0",
 	"features": {
 		"ghcr.io/devcontainers/features/azure-cli:1": {}
 	},

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,54 @@
 # Changelog
 
+## 4.0.0 - 2025-08-22
+
+### Framework upgrade summary 
+
+
+Completed the upgrade to .NET 8.0 LTS across all projects and updated the copilot instructions accordingly. All projects now target .NET 8.0:
+
+- **Main SDK** (`amadeus/amadeus.csproj`): ✅ .NET 8.0
+- **Unit Tests** (`amadeus-test/amadeus-test.csproj`): ✅ .NET 8.0  
+- **Integration Tests** (`amadeus-integration-test/amadeus-integration-test.csproj`): ✅ .NET 8.0
+- **Sample App** (`sample/sample.csproj`): ✅ .NET 8.0
+
+**Updated Instructions:**
+- Removed .NET 6.0 compatibility workarounds
+- Updated framework references to .NET 8.0 LTS throughout
+- Added note about SYSLIB0014 warnings (expected with legacy WebRequest usage)
+- Streamlined build process documentation for .NET 8.0
+
+The project is now fully upgraded to .NET 8.0 LTS with comprehensive development instructions. Commit: fe19777
+
+### Build & Test Modernization Summary
+
+#### Library (`amadeus.csproj`)
+- Removed `docfx.console` PackageReference (eliminated Mono/docfx build failure).
+- Set `DebugType` to `portable` to resolve PDB/sourcelink errors.
+- Upgraded target framework from `net6.0` to `net8.0`.
+- Reverted experimental multi-targeting back to single `net8.0` after `_GetBuildOutputFilesWithTfm` errors.
+
+#### Test Project (`amadeus-test.csproj`)
+- Removed legacy NUnit 2 DLL reference and `packages.config`.
+- Removed `PlatformTarget x64` (now AnyCPU) to support container architecture.
+- Trimmed dependencies to essentials: `Microsoft.NET.Test.Sdk`, `NUnit`, `NUnit3TestAdapter`, `Moq`, `coverlet.collector`.
+- Removed unused xUnit packages.
+- Unified to single `<TargetFramework>net8.0</TargetFramework>` after installing .NET 8 runtime.
+
+#### Outcomes
+- Solution builds successfully (warnings only; mainly XML doc + obsolete API notices).
+- NUnit tests discover and run; Live Unit Testing works.
+- Eliminated causes of prior silent test discovery failures (conflicting NUnit versions, architecture mismatch, missing runtime).
+
+#### Recommended Next Improvements (Optional)
+- Clean malformed XML documentation comments (CS1570/CS1591).
+- Replace obsolete `WebRequest` usages (SYSLIB0014) with `HttpClient`.
+- Add contributor note about required .NET 8 runtime.
+
+
+
+
+
 ## 3.0.0 - 2023-09-12
 
 - Update frameworks to .Net 6

--- a/amadeus-test/amadeus-test.csproj
+++ b/amadeus-test/amadeus-test.csproj
@@ -3,52 +3,19 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>amadeus_test</RootNamespace>
-    
     <IsPackable>false</IsPackable>
-    
-    <PlatformTarget>x64</PlatformTarget>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
- <ItemGroup>
-    <Reference Include="nunit.framework">
-      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="Castle.Core">
-      <HintPath>..\packages\Castle.Core.4.3.1\lib\net45\Castle.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe">
-      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.0\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Threading.Tasks.Extensions">
-      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.1\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
-    </Reference>
-    <Reference Include="Moq">
-      <HintPath>..\packages\Moq.4.10.1\lib\net45\Moq.dll</HintPath>
-    </Reference>
-  </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Castle.Core" Version="5.1.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+  <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.22" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="Moq" Version="4.20.69" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
-    <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+  <PackageReference Include="NUnit" Version="3.14.0" />
+  <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+  <PackageReference Include="Moq" Version="4.20.69" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\amadeus\amadeus.csproj" />

--- a/amadeus/amadeus.csproj
+++ b/amadeus/amadeus.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+  <TargetFramework>net8.0</TargetFramework>
     <PackageId>amadeus-dotnet</PackageId>
     <PackageVersion>30.0</PackageVersion>
 	<Version>3.0.0</Version>


### PR DESCRIPTION
This pull request upgrades the entire project to .NET 8.0 LTS, modernizes the build and test setup, and removes legacy dependencies and workarounds. The changes ensure all projects target .NET 8.0, streamline the development experience, and resolve previous compatibility and test discovery issues.

**Framework Upgrade and Configuration**

* Upgraded all projects (`amadeus`, `amadeus-test`, `amadeus-integration-test`, `sample`) to target .NET 8.0 LTS, and updated the devcontainer image to use the latest .NET 8.0 development container (`mcr.microsoft.com/devcontainers/dotnet:dev-8.0`). (.devcontainer/devcontainer.json)
* Updated documentation in `CHANGELOG.md` to reflect the .NET 8.0 upgrade, removed .NET 6.0 workarounds, and added notes about expected SYSLIB0014 warnings and updated build instructions.

**Test Project Modernization**

* Cleaned up `amadeus-test.csproj` by removing legacy DLL references, `packages.config`, and unnecessary dependencies (including xUnit and old NUnit), and unified the test framework to `net8.0`.
* Updated test dependencies to only include essentials: `Microsoft.NET.Test.Sdk`, `NUnit`, `NUnit3TestAdapter`, `Moq`, and `coverlet.collector`.
* Removed the `PlatformTarget x64` property to improve compatibility with containerized and cross-platform builds.

**Build and Test Improvements**

* Set `DebugType` to `portable` in the main library to resolve PDB and sourcelink errors, and removed the `docfx.console` reference to eliminate Mono/docfx build failures.
* Ensured successful build and test discovery, resolving previous issues with conflicting test frameworks and runtime mismatches.

**Recommended Next Steps**

* Added suggestions in the changelog to clean up malformed XML documentation, replace obsolete `WebRequest` usages, and note the .NET 8 runtime requirement for contributors.